### PR TITLE
Initialize Expo project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
+
+node_modules/
+.buckd/
+.expo/
+.expo-shared/
+web-build/
+dist/
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*

--- a/App.js
+++ b/App.js
@@ -1,0 +1,29 @@
+import { StatusBar } from 'expo-status-bar';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>my-hiit</Text>
+      <Text style={styles.tagline}>HIITワークアウトを便利に行うアプリ</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+  tagline: {
+    marginTop: 8,
+    fontSize: 16,
+  },
+});

--- a/app.json
+++ b/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "my-hiit",
+    "slug": "my-hiit",
+    "version": "1.0.0",
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "my-hiit",
+  "version": "1.0.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^51.0.0",
+    "expo-status-bar": "~1.12.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-native": "0.74.1",
+    "react-native-web": "0.19.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold Expo-based React Native project for my-hiit
- add basic App component and Expo config files
- add tagline to initial App screen

## Testing
- `yarn install` *(fails: RequestError: Bad response: 403)*
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_b_68c0fd8981248331b45ded36a785fdfb